### PR TITLE
Update pngjs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "iconv-lite": "^0.4.8",
     "pako": "^0.2.6",
-    "pngjs": "0.4.0",
+    "pngjs": "3.0.0",
     "request": "^2.55.0",
     "stream-buffers": "1.0.1",
     "underscore": "1.7.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "alpha"
   ],
   "scripts": {
-    "test": "istanbul cover -- _mocha --reporter spec",
+    "test": "mocha --reporter spec",
     "docs": "yuidoc ."
   },
   "dependencies": {
@@ -36,10 +36,7 @@
   },
   "devDependencies": {
     "chai": "1.9.2",
-    "coveralls": "2.11.2",
-    "codeclimate-test-reporter": "0.0.4",
-    "istanbul": "0.3.2",
-    "mocha": "1.21.4",
+    "mocha": "3.1.2",
     "sinon": "1.12.2",
     "sinon-chai": "2.7.0",
     "yuidocjs": "0.3.50"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pngjs-image",
+  "name": "@pandell/pngjs-image",
   "version": "0.11.6",
   "description": "JavaScript-based PNG image encoder, decoder, and manipulator",
   "license": "MIT",
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/yahoo/pngjs-image.git"
+    "url": "https://github.com/pandell/pngjs-image.git"
   },
   "keywords": [
     "PNG",

--- a/test/png/decode/ancillary/text.js
+++ b/test/png/decode/ancillary/text.js
@@ -3,6 +3,7 @@
 
 var testGen = require('../../testGen');
 var expect = require('chai').expect;
+var EOL = require("os").EOL;
 
 describe('Text', function () {
 
@@ -60,7 +61,7 @@ describe('Text', function () {
 					"keyword": "Title"
 				},
 				{
-					"content": "Willem A.J. van Schaik\n(willem@schaik.com)",
+					"content": "Willem A.J. van Schaik" + EOL + "(willem@schaik.com)",
 					"keyword": "Author"
 				},
 				{
@@ -68,7 +69,7 @@ describe('Text', function () {
 					"keyword": "Copyright"
 				},
 				{
-					"content": "A compilation of a set of images created to test the\nvarious color-types of the PNG format. Included are\nblack&white, color, paletted, with alpha channel, with\ntransparency formats. All bit-depths allowed according\nto the spec are present.",
+					"content": "A compilation of a set of images created to test the" + EOL + "various color-types of the PNG format. Included are" + EOL + "black&white, color, paletted, with alpha channel, with" + EOL + "transparency formats. All bit-depths allowed according" + EOL + "to the spec are present.",
 					"keyword": "Description"
 				},
 				{
@@ -113,7 +114,7 @@ describe('Text', function () {
 					"keyword": "Title"
 				},
 				{
-					"content": "Willem A.J. van Schaik\n(willem@schaik.com)",
+					"content": "Willem A.J. van Schaik" + EOL + "(willem@schaik.com)",
 					"keyword": "Author"
 				}
 			]);
@@ -126,7 +127,7 @@ describe('Text', function () {
 					"keyword": "Copyright"
 				},
 				{
-					"content": "A compilation of a set of images created to test the\nvarious color-types of the PNG format. Included are\nblack&white, color, paletted, with alpha channel, with\ntransparency formats. All bit-depths allowed according\nto the spec are present.",
+					"content": "A compilation of a set of images created to test the" + EOL + "various color-types of the PNG format. Included are" + EOL + "black&white, color, paletted, with alpha channel, with" + EOL + "transparency formats. All bit-depths allowed according" + EOL + "to the spec are present.",
 					"keyword": "Description"
 				},
 				{


### PR DESCRIPTION
- Updates to latest `pngjs` dependency, which is compatible with node 4+
- Scopes package to `@pandell`
- Fixes tests on Windows
- Drops code coverage
